### PR TITLE
FIX: Problem with Asterisk Config package #1294 https://github.com/wb…

### DIFF
--- a/Symbol List.tmPreferences
+++ b/Symbol List.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Symbol List: Selectors</string>
 	<key>scope</key>
-	<string>constant.language</string>
+	<string>source.asterisk.config constant.language, source.asterisk.config storage.modifier</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>


### PR DESCRIPTION
FIX: https://github.com/wbond/package_control/issues/1294

https://packagecontrol.io/packages/Asterisk%20Config

When package Asterisk Config installed I see all constants in "outline" (ctrl+r) in other languages (python).

with Asterisk Config package: 
![2017-11-01-125109_791x408_scrot](https://user-images.githubusercontent.com/5524256/32265194-d9e8e27c-bf03-11e7-9f01-5520238165c2.png)

without Asterisk Config package: 
![2017-11-01-122543_723x375_scrot](https://user-images.githubusercontent.com/5524256/32265193-d9bf7cfc-bf03-11e7-93a6-19760240807e.png)

Problem in file Symbol List.tmPreferences

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>name</key>
	<string>Symbol List: Selectors</string>
	<key>scope</key>
	<string>constant.language</string>
	<key>settings</key>
	<dict>
		<key>showInSymbolList</key>
		<integer>1</integer>
	</dict>
	<key>uuid</key>
	<string>01514276-8d8f-49e6-a8f3-08642d7f8b33</string>
</dict>
</plist>
```

It globaly enables showInSymbolList

I cant make issue in repository https://github.com/pnlarsson/SublimeAsteriskConfig.
